### PR TITLE
Adiciona páginas e interface em português

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ import Layout from './components/layout/layout';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
 import Products from './pages/Products';
+import Clients from './pages/Clients';
+import Orders from './pages/Orders';
+import Transactions from './pages/Transactions';
 
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   const { isAuthenticated, isLoading } = useAuth();
@@ -58,6 +61,36 @@ function App() {
                         <ProtectedRoute>
                           <Layout>
                             <Products />
+                          </Layout>
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/clientes"
+                      element={
+                        <ProtectedRoute>
+                          <Layout>
+                            <Clients />
+                          </Layout>
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/pedidos"
+                      element={
+                        <ProtectedRoute>
+                          <Layout>
+                            <Orders />
+                          </Layout>
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/transacoes"
+                      element={
+                        <ProtectedRoute>
+                          <Layout>
+                            <Transactions />
                           </Layout>
                         </ProtectedRoute>
                       }

--- a/src/components/dashboard/DashboardCards.tsx
+++ b/src/components/dashboard/DashboardCards.tsx
@@ -122,7 +122,7 @@ export function DashboardCards() {
       {/* Product Card */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between pb-2">
-          <CardTitle className="text-sm font-medium">Products</CardTitle>
+          <CardTitle className="text-sm font-medium">Produtos</CardTitle>
           <Package className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
@@ -207,13 +207,13 @@ export function DashboardCards() {
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
-            ${stats.totalRevenue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            {stats.totalRevenue.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
           </div>
           <p className="text-xs text-muted-foreground">
             {stats.revenueThisMonth > 0 ? (
               <span className="flex items-center text-primary">
                 <ArrowUpRight className="mr-1 h-3 w-3" />
-                ${stats.revenueThisMonth.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} Este mês
+                {stats.revenueThisMonth.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })} Este mês
               </span>
             ) : (
               <span className="flex items-center">
@@ -247,8 +247,8 @@ export function DashboardCards() {
                 <YAxis yAxisId="left" orientation="left" stroke="hsl(var(--chart-1))" />
                 <YAxis yAxisId="right" orientation="right" stroke="hsl(var(--chart-2))" />
                 <Tooltip />
-                <Bar yAxisId="left" dataKey="revenue" fill="hsl(var(--chart-1))" name="Revenue ($)" />
-                <Bar yAxisId="right" dataKey="orders" fill="hsl(var(--chart-2))" name="Orders" />
+                <Bar yAxisId="left" dataKey="revenue" fill="hsl(var(--chart-1))" name="Receita" />
+                <Bar yAxisId="right" dataKey="orders" fill="hsl(var(--chart-2))" name="Pedidos" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -278,8 +278,11 @@ export function DashboardCards() {
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>
-                <Tooltip 
-                  formatter={(value) => [`$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, 'Value']}
+                <Tooltip
+                  formatter={(value) => [
+                    `R$ ${value.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                    'Valor'
+                  ]}
                 />
               </PieChart>
             </ResponsiveContainer>

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -7,9 +7,7 @@ import {
   Users,
   ShoppingCart,
   Truck,
-  BarChart3,
   Receipt,
-  Settings,
   LogOut,
   Menu,
   X,
@@ -89,22 +87,6 @@ export default function Layout({ children }: { children: ReactNode }) {
       title: "Transações",
       href: "/transacoes",
       icon: <Receipt className="h-5 w-5" />,
-    },
-    {
-      title: "Relatórios",
-      href: "/relatorios",
-      icon: <BarChart3 className="h-5 w-5" />,
-    },
-    {
-      title: "Usuários",
-      href: "/usuarios",
-      icon: <User className="h-5 w-5" />,
-      requireAdmin: true,
-    },
-    {
-      title: "Configurações",
-      href: "/configuracoes",
-      icon: <Settings className="h-5 w-5" />,
     },
   ];
 
@@ -216,10 +198,6 @@ export default function Layout({ children }: { children: ReactNode }) {
                     <User className="mr-2 h-4 w-4" />
                     Perfil
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => navigate("/configuracoes")}>
-                    <Settings className="mr-2 h-4 w-4" />
-                    Configurações
-                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleLogout}>
                     <LogOut className="mr-2 h-4 w-4" />
@@ -243,7 +221,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           </nav>
         </aside>
 
-        <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
+        <main className="mx-auto flex-1 max-w-7xl overflow-auto p-4 md:p-6">{children}</main>
       </div>
 
       <Toaster />

--- a/src/contexts/ClientContext.tsx
+++ b/src/contexts/ClientContext.tsx
@@ -76,8 +76,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     if (documentExists) {
       toast({
         variant: 'destructive',
-        title: 'Error creating client',
-        description: `A client with this ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'} already exists`,
+        title: 'Erro ao criar cliente',
+        description: `Já existe cliente com este ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'}`,
       });
       throw new Error(`A client with this ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'} already exists`);
     }
@@ -86,8 +86,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     if (!validateDocument(clientData.document, clientData.documentType)) {
       toast({
         variant: 'destructive',
-        title: 'Error creating client',
-        description: `Invalid ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'} format`,
+        title: 'Erro ao criar cliente',
+        description: `Formato de ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'} inválido`,
       });
       throw new Error(`Invalid ${clientData.documentType === 'cpf' ? 'CPF' : 'CNPJ'} format`);
     }
@@ -102,8 +102,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setClients([...clients, newClient]);
     
     toast({
-      title: 'Client created',
-      description: 'Client has been created successfully',
+      title: 'Cliente criado',
+      description: 'Cliente cadastrado com sucesso',
     });
     
     return newClient;
@@ -124,8 +124,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     if (documentExists) {
       toast({
         variant: 'destructive',
-        title: 'Error updating client',
-        description: `A client with this ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'} already exists`,
+        title: 'Erro ao atualizar',
+        description: `Já existe cliente com este ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'}`,
       });
       throw new Error(`A client with this ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'} already exists`);
     }
@@ -134,8 +134,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     if (!validateDocument(updatedClient.document, updatedClient.documentType)) {
       toast({
         variant: 'destructive',
-        title: 'Error updating client',
-        description: `Invalid ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'} format`,
+        title: 'Erro ao atualizar',
+        description: `Formato de ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'} inválido`,
       });
       throw new Error(`Invalid ${updatedClient.documentType === 'cpf' ? 'CPF' : 'CNPJ'} format`);
     }
@@ -149,8 +149,8 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setClients(updatedClients);
     
     toast({
-      title: 'Client updated',
-      description: 'Client has been updated successfully',
+      title: 'Cliente atualizado',
+      description: 'Cliente atualizado com sucesso',
     });
   };
 
@@ -166,7 +166,7 @@ export const ClientProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setClients(updatedClients);
     
     toast({
-      title: 'Client deactivated',
+      title: 'Cliente desativado',
       description: 'Cliente desativado com sucesso',
     });
   };

--- a/src/contexts/OrderContext.tsx
+++ b/src/contexts/OrderContext.tsx
@@ -83,8 +83,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (orderData.items.length === 0) {
       toast({
         variant: 'destructive',
-        title: 'Error creating order',
-        description: 'Order must have at least one item',
+        title: 'Erro ao criar pedido',
+        description: 'O pedido deve ter ao menos um item',
       });
       throw new Error('Order must have at least one item');
     }
@@ -96,8 +96,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (!product) {
         toast({
           variant: 'destructive',
-          title: 'Error creating order',
-          description: `Product with ID ${item.productId} not found`,
+          title: 'Erro ao criar pedido',
+          description: `Produto com ID ${item.productId} não encontrado`,
         });
         throw new Error(`Product with ID ${item.productId} not found`);
       }
@@ -105,8 +105,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (product.stockQuantity < item.quantity) {
         toast({
           variant: 'destructive',
-          title: 'Error creating order',
-          description: `Not enough stock for product: ${product.name}`,
+          title: 'Erro ao criar pedido',
+          description: `Estoque insuficiente para o produto: ${product.name}`,
         });
         throw new Error(`Not enough stock for product: ${product.name}`);
       }
@@ -128,8 +128,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setOrders([...orders, newOrder]);
     
     toast({
-      title: 'Order created',
-      description: 'Order has been created successfully',
+      title: 'Pedido criado',
+      description: 'Pedido registrado com sucesso',
     });
     
     return newOrder;
@@ -144,8 +144,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!existingOrder) {
       toast({
         variant: 'destructive',
-        title: 'Error updating order',
-        description: 'Order not found',
+        title: 'Erro ao atualizar pedido',
+        description: 'Pedido não encontrado',
       });
       throw new Error('Order not found');
     }
@@ -174,8 +174,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setOrders(updatedOrders);
     
     toast({
-      title: 'Order updated',
-      description: 'Order has been updated successfully',
+      title: 'Pedido atualizado',
+      description: 'Pedido atualizado com sucesso',
     });
   };
 
@@ -185,8 +185,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!order) {
       toast({
         variant: 'destructive',
-        title: 'Error deleting order',
-        description: 'Order not found',
+        title: 'Erro ao excluir pedido',
+        description: 'Pedido não encontrado',
       });
       return;
     }
@@ -209,8 +209,8 @@ export const OrderProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setOrders(updatedOrders);
     
     toast({
-      title: 'Order deleted',
-      description: 'Order has been deleted successfully',
+      title: 'Pedido excluído',
+      description: 'Pedido excluído com sucesso',
     });
   };
 

--- a/src/contexts/ProductContext.tsx
+++ b/src/contexts/ProductContext.tsx
@@ -115,8 +115,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setProducts([...products, newProduct]);
     
     toast({
-      title: 'Product created',
-      description: 'Product has been created successfully',
+      title: 'Produto criado',
+      description: 'Produto cadastrado com sucesso',
     });
     
     return newProduct;
@@ -135,8 +135,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setProducts(updatedProducts);
     
     toast({
-      title: 'Product updated',
-      description: 'Product has been updated successfully',
+      title: 'Produto atualizado',
+      description: 'Produto atualizado com sucesso',
     });
   };
 
@@ -150,8 +150,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setProducts(updatedProducts);
     
     toast({
-      title: 'Product deleted',
-      description: 'Product has been deleted successfully',
+      title: 'Produto removido',
+      description: 'Produto removido com sucesso',
     });
   };
 
@@ -247,8 +247,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setCategories([...categories, newCategory]);
     
     toast({
-      title: 'Category created',
-      description: 'Category has been created successfully',
+      title: 'Categoria criada',
+      description: 'Categoria cadastrada com sucesso',
     });
     
     return newCategory;
@@ -267,8 +267,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setCategories(updatedCategories);
     
     toast({
-      title: 'Category updated',
-      description: 'Category has been updated successfully',
+      title: 'Categoria atualizada',
+      description: 'Categoria atualizada com sucesso',
     });
   };
 
@@ -281,8 +281,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     if (productsWithCategory.length > 0) {
       toast({
         variant: 'destructive',
-        title: 'Cannot delete category',
-        description: `This category is used by ${productsWithCategory.length} active products`,
+        title: 'Não é possível excluir',
+        description: `Esta categoria é usada por ${productsWithCategory.length} produtos ativos`,
       });
       return;
     }
@@ -291,8 +291,8 @@ export const ProductProvider: React.FC<{ children: React.ReactNode }> = ({ child
     setCategories(updatedCategories);
     
     toast({
-      title: 'Category deleted',
-      description: 'Category has been deleted successfully',
+      title: 'Categoria removida',
+      description: 'Categoria removida com sucesso',
     });
   };
 

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -76,8 +76,8 @@ export const TransactionProvider: React.FC<{ children: React.ReactNode }> = ({ c
     if (transactionData.amount <= 0) {
       toast({
         variant: 'destructive',
-        title: 'Error creating transaction',
-        description: 'Transaction amount must be greater than zero',
+        title: 'Erro ao criar transação',
+        description: 'O valor deve ser maior que zero',
       });
       throw new Error('Transaction amount must be greater than zero');
     }
@@ -92,8 +92,8 @@ export const TransactionProvider: React.FC<{ children: React.ReactNode }> = ({ c
     setTransactions([...transactions, newTransaction]);
     
     toast({
-      title: 'Transaction created',
-      description: 'Transaction has been created successfully',
+      title: 'Transação criada',
+      description: 'Transação registrada com sucesso',
     });
     
     return newTransaction;
@@ -107,8 +107,8 @@ export const TransactionProvider: React.FC<{ children: React.ReactNode }> = ({ c
     if (updatedTransaction.amount <= 0) {
       toast({
         variant: 'destructive',
-        title: 'Error updating transaction',
-        description: 'Transaction amount must be greater than zero',
+        title: 'Erro ao atualizar transação',
+        description: 'O valor deve ser maior que zero',
       });
       throw new Error('Transaction amount must be greater than zero');
     }
@@ -122,8 +122,8 @@ export const TransactionProvider: React.FC<{ children: React.ReactNode }> = ({ c
     setTransactions(updatedTransactions);
     
     toast({
-      title: 'Transaction updated',
-      description: 'Transaction has been updated successfully',
+      title: 'Transação atualizada',
+      description: 'Transação atualizada com sucesso',
     });
   };
 
@@ -132,8 +132,8 @@ export const TransactionProvider: React.FC<{ children: React.ReactNode }> = ({ c
     setTransactions(updatedTransactions);
     
     toast({
-      title: 'Transaction deleted',
-      description: 'Transaction has been deleted successfully',
+      title: 'Transação removida',
+      description: 'Transação removida com sucesso',
     });
   };
 

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useClients } from "@/contexts/ClientContext";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const clientSchema = z.object({
+  name: z.string().min(1, "Nome é obrigatório"),
+  email: z.string().email("E-mail inválido"),
+  phone: z.string().min(1, "Telefone é obrigatório"),
+  document: z.string().min(1, "Documento é obrigatório"),
+  documentType: z.enum(["cpf", "cnpj"]),
+});
+
+type ClientFormValues = z.infer<typeof clientSchema>;
+
+export default function Clients() {
+  const { createClient } = useClients();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const form = useForm<ClientFormValues>({
+    resolver: zodResolver(clientSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      phone: "",
+      document: "",
+      documentType: "cpf",
+    },
+  });
+
+  const onSubmit = async (data: ClientFormValues) => {
+    try {
+      await createClient({
+        ...data,
+        address: {
+          street: "",
+          number: "",
+          neighborhood: "",
+          city: "",
+          state: "",
+          zipCode: "",
+          country: "",
+        },
+        isActive: true,
+      });
+      setIsDialogOpen(false);
+      form.reset();
+    } catch (err) {
+      console.error("Erro ao criar cliente", err);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Clientes"
+        description="Gerencie sua base de clientes"
+        action={{
+          label: "Novo Cliente",
+          onClick: () => setIsDialogOpen(true),
+          icon: <Plus className="h-4 w-4" />,
+        }}
+      />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Novo Cliente</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nome completo" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="email@exemplo.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Telefone</FormLabel>
+                    <FormControl>
+                      <Input placeholder="(00) 00000-0000" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="document"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Documento</FormLabel>
+                      <FormControl>
+                        <Input placeholder="CPF ou CNPJ" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="documentType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tipo</FormLabel>
+                      <FormControl>
+                        <select
+                          {...field}
+                          className="w-full rounded border px-2 py-1 bg-background"
+                        >
+                          <option value="cpf">CPF</option>
+                          <option value="cnpj">CNPJ</option>
+                        </select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="flex justify-end gap-4">
+                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,9 +25,9 @@ export function Dashboard() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Painel</h1>
         <p className="text-sm text-muted-foreground">
-          Bem vindo de volta, {user?.name || 'User'}!
+          Bem vindo de volta, {user?.name || 'Usuário'}!
         </p>
       </div>
       

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useOrders } from "@/contexts/OrderContext";
+import { useClients } from "@/contexts/ClientContext";
+import { useProducts } from "@/contexts/ProductContext";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const orderSchema = z.object({
+  clientId: z.string().min(1, "Cliente obrigatório"),
+  productId: z.string().min(1, "Produto obrigatório"),
+  quantity: z.number().int().min(1, "Quantidade mínima 1"),
+});
+
+type OrderFormValues = z.infer<typeof orderSchema>;
+
+export default function Orders() {
+  const { clients } = useClients();
+  const { products } = useProducts();
+  const { createOrder, generateOrderNumber, calculateOrderTotal } = useOrders();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const form = useForm<OrderFormValues>({
+    resolver: zodResolver(orderSchema),
+    defaultValues: { clientId: "", productId: "", quantity: 1 },
+  });
+
+  const onSubmit = async (data: OrderFormValues) => {
+    const product = products.find((p) => p.id === data.productId);
+    if (!product) return;
+
+    const item = {
+      id: `item_${Date.now()}`,
+      productId: product.id,
+      quantity: data.quantity,
+      unitPrice: product.price,
+      discount: 0,
+      total: product.price * data.quantity,
+    };
+
+    await createOrder({
+      clientId: data.clientId,
+      userId: "1",
+      orderNumber: generateOrderNumber(),
+      status: "completed",
+      paymentStatus: "paid",
+      paymentMethod: "cash",
+      items: [item],
+      discount: 0,
+      tax: 0,
+      shipping: 0,
+      total: calculateOrderTotal([item], 0, 0, 0),
+      notes: "",
+    });
+
+    setIsDialogOpen(false);
+    form.reset();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Pedidos"
+        description="Registre novos pedidos"
+        action={{
+          label: "Novo Pedido",
+          onClick: () => setIsDialogOpen(true),
+          icon: <Plus className="h-4 w-4" />,
+        }}
+      />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Novo Pedido</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="clientId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Cliente</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Selecione" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {clients.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="productId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Produto</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Selecione" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {products.map((p) => (
+                          <SelectItem key={p.id} value={p.id}>
+                            {p.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="quantity"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Quantidade</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        {...field}
+                        onChange={(e) => field.onChange(parseInt(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end gap-4">
+                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTransactions } from "@/contexts/TransactionContext";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const transSchema = z.object({
+  type: z.enum(["income", "expense"]),
+  amount: z.number().min(0.01, "Valor deve ser positivo"),
+  description: z.string().min(1, "Descrição obrigatória"),
+  date: z.string(),
+  category: z.string().min(1, "Categoria obrigatória"),
+});
+
+type TransFormValues = z.infer<typeof transSchema>;
+
+export default function Transactions() {
+  const { createTransaction } = useTransactions();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const form = useForm<TransFormValues>({
+    resolver: zodResolver(transSchema),
+    defaultValues: {
+      type: "income",
+      amount: 0,
+      description: "",
+      date: new Date().toISOString().substring(0, 10),
+      category: "other",
+    },
+  });
+
+  const onSubmit = async (data: TransFormValues) => {
+    await createTransaction({
+      ...data,
+      userId: "1",
+    });
+    setIsDialogOpen(false);
+    form.reset();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Transações"
+        description="Registre entradas e saídas"
+        action={{
+          label: "Nova Transação",
+          onClick: () => setIsDialogOpen(true),
+          icon: <Plus className="h-4 w-4" />,
+        }}
+      />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Nova Transação</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Tipo</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="income">Entrada</SelectItem>
+                        <SelectItem value="expense">Saída</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="amount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Valor</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        {...field}
+                        onChange={(e) => field.onChange(parseFloat(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Descrição</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Data</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="category"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Categoria</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end gap-4">
+                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumo
- centraliza `main` no layout
- traduz interface e toasts para português
- remove itens de relatórios, usuários e configurações do menu
- adiciona páginas de Clientes, Pedidos e Transações
- ajusta Dashboard para moeda brasileira

## Testes
- `npm run lint` *(falha: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d85efdec8832b9e6f4697c6abd2a0