### PR TITLE
Add supplier management and dashboard enhancements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
 import Products from './pages/Products';
 import Clients from './pages/Clients';
+import Suppliers from './pages/Suppliers';
 import Orders from './pages/Orders';
 import Transactions from './pages/Transactions';
 
@@ -71,6 +72,16 @@ function App() {
                         <ProtectedRoute>
                           <Layout>
                             <Clients />
+                          </Layout>
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/fornecedores"
+                      element={
+                        <ProtectedRoute>
+                          <Layout>
+                            <Suppliers />
                           </Layout>
                         </ProtectedRoute>
                       }

--- a/src/components/dashboard/DashboardCards.tsx
+++ b/src/components/dashboard/DashboardCards.tsx
@@ -6,10 +6,12 @@ import { useProducts } from '@/contexts/ProductContext';
 import { useClients } from '@/contexts/ClientContext';
 import { useOrders } from '@/contexts/OrderContext';
 import { useTransactions } from '@/contexts/TransactionContext';
+import { useSuppliers } from '@/contexts/SupplierContext';
 import { 
   Package, 
   Users, 
-  ShoppingCart, 
+  ShoppingCart,
+  Truck,
   TrendingUp,
   TrendingDown,
   ArrowUpRight,
@@ -19,6 +21,7 @@ import {
 export function DashboardCards() {
   const { products } = useProducts();
   const { clients } = useClients();
+  const { suppliers } = useSuppliers();
   const { orders } = useOrders();
   const { transactions } = useTransactions();
   
@@ -28,6 +31,8 @@ export function DashboardCards() {
     lowStockProducts: 0,
     totalClients: 0,
     activeClients: 0,
+    totalSuppliers: 0,
+    activeSuppliers: 0,
     totalOrders: 0,
     ordersThisMonth: 0,
     totalRevenue: 0,
@@ -45,6 +50,7 @@ export function DashboardCards() {
     const activeProducts = products.filter((p) => p.isActive);
     const lowStockProducts = activeProducts.filter((p) => p.stockQuantity < 10);
     const activeClients = clients.filter((c) => c.isActive);
+    const activeSuppliers = suppliers.filter((s) => s.isActive);
     
     // Current date info
     const now = new Date();
@@ -66,6 +72,8 @@ export function DashboardCards() {
       lowStockProducts: lowStockProducts.length,
       totalClients: clients.length,
       activeClients: activeClients.length,
+      totalSuppliers: suppliers.length,
+      activeSuppliers: activeSuppliers.length,
       totalOrders: orders.length,
       ordersThisMonth: ordersThisMonth.length,
       totalRevenue,
@@ -163,7 +171,31 @@ export function DashboardCards() {
           </p>
         </CardContent>
       </Card>
-      
+
+      {/* Suppliers Card */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Fornecedores</CardTitle>
+          <Truck className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.activeSuppliers}</div>
+          <p className="text-xs text-muted-foreground">
+            <span className="flex items-center">
+              {stats.activeSuppliers === stats.totalSuppliers ? (
+                <TrendingUp className="mr-1 h-3 w-3 text-primary" />
+              ) : (
+                <TrendingDown className="mr-1 h-3 w-3 text-muted-foreground" />
+              )}
+              {stats.totalSuppliers > 0
+                ? ((stats.activeSuppliers / stats.totalSuppliers) * 100).toFixed(0)
+                : 0}
+              % ativo
+            </span>
+          </p>
+        </CardContent>
+      </Card>
+
       {/* Orders Card */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between pb-2">

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -57,6 +57,29 @@ export default function Layout({ children }: { children: ReactNode }) {
     });
   };
 
+  const handleExportData = () => {
+    const data = {
+      products: JSON.parse(localStorage.getItem("products") || "[]"),
+      categories: JSON.parse(localStorage.getItem("categories") || "[]"),
+      clients: JSON.parse(localStorage.getItem("clients") || "[]"),
+      suppliers: JSON.parse(localStorage.getItem("suppliers") || "[]"),
+      orders: JSON.parse(localStorage.getItem("orders") || "[]"),
+      transactions: JSON.parse(localStorage.getItem("transactions") || "[]"),
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "backup.json";
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleResetApp = () => {
+    localStorage.clear();
+    window.location.reload();
+  };
+
   const navItems: NavItem[] = [
     {
       title: "Painel",
@@ -197,6 +220,14 @@ export default function Layout({ children }: { children: ReactNode }) {
                   <DropdownMenuItem onClick={() => navigate("/perfil")}>
                     <User className="mr-2 h-4 w-4" />
                     Perfil
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleExportData}>
+                    <ChevronDown className="mr-2 h-4 w-4" />
+                    Exportar dados
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleResetApp}>
+                    <ChevronDown className="mr-2 h-4 w-4" />
+                    Limpar dados
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleLogout}>

--- a/src/contexts/SupplierContext.tsx
+++ b/src/contexts/SupplierContext.tsx
@@ -9,6 +9,7 @@ const INITIAL_SUPPLIERS: Supplier[] = [
     id: 'sup_1',
     name: 'Tech Distributors Inc.',
     contactName: 'Sarah Johnson',
+    product: 'Eletrônicos',
     email: 'sjohnson@techdist.com',
     phone: '555-789-1234',
     document: '12.345.678/0001-90',
@@ -30,6 +31,7 @@ const INITIAL_SUPPLIERS: Supplier[] = [
     id: 'sup_2',
     name: 'Office Solutions Ltd.',
     contactName: 'Michael Chen',
+    product: 'Móveis para escritório',
     email: 'mchen@officesolutions.com',
     phone: '555-456-7890',
     document: '98.765.432/0001-10',
@@ -51,6 +53,7 @@ const INITIAL_SUPPLIERS: Supplier[] = [
     id: 'sup_3',
     name: 'Fashion Wholesale Co.',
     contactName: 'Emma Rodriguez',
+    product: 'Roupas',
     email: 'erodriguez@fashionwholesale.com',
     phone: '555-321-6547',
     document: '87.654.321/0001-01',
@@ -200,9 +203,10 @@ export const SupplierProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       // By default, only show active suppliers
       if (!supplier.isActive) return false;
       
-      // Search by name, contact name, email, or document
+      // Search by name, product, contact name, email, or document
       const matchesSearch = search
         ? supplier.name.toLowerCase().includes(search.toLowerCase()) ||
+          supplier.product.toLowerCase().includes(search.toLowerCase()) ||
           supplier.contactName.toLowerCase().includes(search.toLowerCase()) ||
           supplier.email.toLowerCase().includes(search.toLowerCase()) ||
           supplier.document.includes(search)

--- a/src/pages/Suppliers.tsx
+++ b/src/pages/Suppliers.tsx
@@ -1,0 +1,274 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { useSuppliers } from "@/contexts/SupplierContext";
+import { Supplier } from "@/types";
+
+import { PageHeader } from "@/components/common/PageHeader";
+import { Plus, Edit, Trash } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
+
+const supplierSchema = z.object({
+  name: z.string().min(1, "Nome é obrigatório"),
+  product: z.string().min(1, "Produto é obrigatório"),
+  document: z.string().min(1, "CNPJ é obrigatório"),
+  phone: z.string().min(1, "Telefone é obrigatório"),
+  email: z.string().email("E-mail inválido"),
+  isActive: z.boolean().default(true),
+});
+
+type SupplierFormValues = z.infer<typeof supplierSchema>;
+
+export default function Suppliers() {
+  const { suppliers, createSupplier, updateSupplier, deleteSupplier } = useSuppliers();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingSupplier, setEditingSupplier] = useState<Supplier | null>(null);
+  const [search, setSearch] = useState("");
+
+  const form = useForm<SupplierFormValues>({
+    resolver: zodResolver(supplierSchema),
+    defaultValues: {
+      name: "",
+      product: "",
+      document: "",
+      phone: "",
+      email: "",
+      isActive: true,
+    },
+  });
+
+  const emptyAddress = {
+    street: "",
+    number: "",
+    neighborhood: "",
+    city: "",
+    state: "",
+    zipCode: "",
+    country: "",
+  };
+
+  const openNew = () => {
+    setEditingSupplier(null);
+    form.reset({
+      name: "",
+      product: "",
+      document: "",
+      phone: "",
+      email: "",
+      isActive: true,
+    });
+    setIsDialogOpen(true);
+  };
+
+  const openEdit = (supplier: Supplier) => {
+    setEditingSupplier(supplier);
+    form.reset({
+      name: supplier.name,
+      product: supplier.product,
+      document: supplier.document,
+      phone: supplier.phone,
+      email: supplier.email,
+      isActive: supplier.isActive,
+    });
+    setIsDialogOpen(true);
+  };
+
+  const onSubmit = (data: SupplierFormValues) => {
+    if (editingSupplier) {
+      updateSupplier({ ...editingSupplier, ...data });
+    } else {
+      createSupplier({
+        ...data,
+        contactName: "",
+        address: emptyAddress,
+      });
+    }
+    setIsDialogOpen(false);
+  };
+
+  const handleDelete = (id: string) => {
+    deleteSupplier(id);
+  };
+
+  const filtered = suppliers.filter((s) => {
+    const term = search.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(term) ||
+      s.product.toLowerCase().includes(term) ||
+      s.document.includes(term)
+    );
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Fornecedores"
+        description="Gerencie sua base de fornecedores"
+        action={{
+          label: "Novo Fornecedor",
+          onClick: openNew,
+          icon: <Plus className="h-4 w-4" />,
+        }}
+      >
+        <div className="pt-2">
+          <Input
+            placeholder="Buscar fornecedor..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="max-w-sm"
+          />
+        </div>
+      </PageHeader>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nome</TableHead>
+            <TableHead>Produto</TableHead>
+            <TableHead>CNPJ</TableHead>
+            <TableHead>Telefone</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((s) => (
+            <TableRow key={s.id}>
+              <TableCell>{s.name}</TableCell>
+              <TableCell>{s.product}</TableCell>
+              <TableCell>{s.document}</TableCell>
+              <TableCell>{s.phone}</TableCell>
+              <TableCell>{s.email}</TableCell>
+              <TableCell>{s.isActive ? "Ativo" : "Inativo"}</TableCell>
+              <TableCell className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => openEdit(s)}>
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => handleDelete(s.id)}>
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>
+              {editingSupplier ? "Editar Fornecedor" : "Novo Fornecedor"}
+            </DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="product"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Produto fornecido</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="document"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>CNPJ</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Telefone</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="isActive"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-3">
+                    <FormLabel>Status ativo</FormLabel>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-4">
+                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,8 @@ export interface Address {
 // Supplier types
 export interface Supplier extends BaseEntity {
   name: string;
+  /** Produto fornecido pelo fornecedor */
+  product: string;
   contactName: string;
   email: string;
   phone: string;


### PR DESCRIPTION
## Summary
- add supplier interface field `product` and seed sample data
- expose export/reset options in layout dropdown
- integrate suppliers in dashboard stats
- create full Suppliers page with CRUD and search
- add route for suppliers page

## Testing
- `npm run build` *(fails: missing modules due to offline env)*

------
https://chatgpt.com/codex/tasks/task_e_685d9b076fc8832b9f8a9ac44d622c42