### PR TITLE
Add image URL field to product form

### DIFF
--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -367,6 +367,20 @@ export default function Products() {
                 )}
               />
 
+              <FormField
+                control={form.control}
+                name="imageUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL da Imagem</FormLabel>
+                    <FormControl>
+                      <Input placeholder="https://exemplo.com/imagem.jpg" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               <div className="flex justify-end gap-4">
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary
- include input for product `imageUrl` in the Products page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685dadd86630832ba93851fb78580feb