### PR TITLE
Add product editing and deletion

### DIFF
--- a/src/components/products/ProductForm.tsx
+++ b/src/components/products/ProductForm.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
+import { Product } from '@/types';
 
 const schema = z.object({
   name: z.string().min(1, 'Nome é obrigatório'),
@@ -26,31 +27,42 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-export function ProductForm() {
-  const { categories = [], createProduct } = useProducts();
+interface ProductFormProps {
+  product?: Product;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+}
+
+export function ProductForm({ product, onCancel, onSuccess }: ProductFormProps) {
+  const { categories = [], createProduct, updateProduct } = useProducts();
   const { suppliers } = useSuppliers();
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
-      name: '',
-      sku: '',
-      price: 0,
-      stockQuantity: 0,
-      categoryId: '',
-      supplierId: '',
+      name: product?.name ?? '',
+      sku: product?.sku ?? '',
+      price: product?.price ?? 0,
+      stockQuantity: product?.stockQuantity ?? 0,
+      categoryId: product?.categoryId ?? '',
+      supplierId: product?.supplierId ?? '',
     },
   });
 
   const onSubmit = async (data: FormValues) => {
-    await createProduct({
-      ...data,
-      description: '',
-      cost: 0,
-      imageUrl: '',
-      isActive: true,
-    });
-    form.reset();
+    if (product) {
+      updateProduct({ ...product, ...data });
+    } else {
+      await createProduct({
+        ...data,
+        description: '',
+        cost: 0,
+        imageUrl: '',
+        isActive: true,
+      });
+      form.reset();
+    }
+    onSuccess?.();
   };
 
   return (
@@ -177,7 +189,12 @@ export function ProductForm() {
           )}
         />
 
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-4">
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancelar
+            </Button>
+          )}
           <Button type="submit">Salvar</Button>
         </div>
       </form>

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -1,8 +1,22 @@
 import { useProducts } from '@/contexts/ProductContext';
 import { useSuppliers } from '@/contexts/SupplierContext';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Edit, Trash } from 'lucide-react';
+import { Product } from '@/types';
 
-export function ProductList() {
+interface ProductListProps {
+  onEdit: (product: Product) => void;
+  onDelete: (id: string) => void;
+}
+export function ProductList({ onEdit, onDelete }: ProductListProps) {
   const { products, categories = [] } = useProducts();
   const { suppliers } = useSuppliers();
 
@@ -18,6 +32,7 @@ export function ProductList() {
           <TableHead>Fornecedor</TableHead>
           <TableHead>Preço</TableHead>
           <TableHead>Estoque</TableHead>
+          <TableHead className="text-right">Ações</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -34,6 +49,18 @@ export function ProductList() {
                 {p.price.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
               </TableCell>
               <TableCell>{p.stockQuantity}</TableCell>
+              <TableCell className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => onEdit(p)}>
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onDelete(p.id)}
+                >
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </TableCell>
             </TableRow>
           );
         })}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,8 +1,30 @@
+import { useState } from 'react';
 import { PageHeader } from '@/components/common/PageHeader';
 import ProductForm from '@/components/products/ProductForm';
 import ProductList from '@/components/products/ProductList';
+import { useProducts } from '@/contexts/ProductContext';
+import { Product } from '@/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
 export default function Products() {
+  const { deleteProduct } = useProducts();
+  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const openEdit = (product: Product) => {
+    setEditingProduct(product);
+    setIsDialogOpen(true);
+  };
+
+  const handleDelete = (id: string) => {
+    deleteProduct(id);
+  };
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    setEditingProduct(null);
+  };
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -10,7 +32,22 @@ export default function Products() {
         description="Cadastre e visualize seus produtos"
       />
       <ProductForm />
-      <ProductList />
+      <ProductList onEdit={openEdit} onDelete={handleDelete} />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Editar Produto</DialogTitle>
+          </DialogHeader>
+          {editingProduct && (
+            <ProductForm
+              product={editingProduct}
+              onCancel={closeDialog}
+              onSuccess={closeDialog}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support editing existing products and cancelling edits
- display edit/delete actions in product list
- update Products page with dialog to edit products

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685db40029dc832b9acc2e5883b42c37