### PR TITLE
Add order and transaction lists

### DIFF
--- a/src/components/orders/OrderList.tsx
+++ b/src/components/orders/OrderList.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { format } from "date-fns";
+import { useOrders } from "@/contexts/OrderContext";
+import { useClients } from "@/contexts/ClientContext";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+
+export default function OrderList() {
+  const { orders } = useOrders();
+  const { clients } = useClients();
+  const [search, setSearch] = useState("");
+
+  const filtered = orders.filter((order) => {
+    const term = search.toLowerCase();
+    const client = clients.find((c) => c.id === order.clientId);
+    const clientName = client ? client.name.toLowerCase() : "";
+    return (
+      order.orderNumber.toLowerCase().includes(term) ||
+      clientName.includes(term)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Buscar pedido..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Número</TableHead>
+            <TableHead>Cliente</TableHead>
+            <TableHead>Data</TableHead>
+            <TableHead>Total</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((order) => {
+            const client = clients.find((c) => c.id === order.clientId);
+            return (
+              <TableRow key={order.id}>
+                <TableCell>{order.orderNumber}</TableCell>
+                <TableCell>{client?.name ?? "-"}</TableCell>
+                <TableCell>{format(new Date(order.createdAt), "P")}</TableCell>
+                <TableCell>
+                  {order.total.toLocaleString("pt-BR", {
+                    style: "currency",
+                    currency: "BRL",
+                  })}
+                </TableCell>
+                <TableCell>{order.status}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { format } from "date-fns";
+import { useTransactions } from "@/contexts/TransactionContext";
+import { useOrders } from "@/contexts/OrderContext";
+import { useSuppliers } from "@/contexts/SupplierContext";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+
+export default function TransactionList() {
+  const { transactions } = useTransactions();
+  const { orders } = useOrders();
+  const { suppliers } = useSuppliers();
+  const [search, setSearch] = useState("");
+
+  const filtered = transactions.filter((t) => {
+    const term = search.toLowerCase();
+    const orderNumber = t.orderId
+      ? orders.find((o) => o.id === t.orderId)?.orderNumber.toLowerCase() || ""
+      : "";
+    const supplierName = t.supplierId
+      ? suppliers.find((s) => s.id === t.supplierId)?.name.toLowerCase() || ""
+      : "";
+    return (
+      t.description.toLowerCase().includes(term) ||
+      t.category.toLowerCase().includes(term) ||
+      orderNumber.includes(term) ||
+      supplierName.includes(term)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Buscar transação..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Data</TableHead>
+            <TableHead>Descrição</TableHead>
+            <TableHead>Valor</TableHead>
+            <TableHead>Tipo</TableHead>
+            <TableHead>Categoria</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>{format(new Date(t.date), "P")}</TableCell>
+              <TableCell>{t.description}</TableCell>
+              <TableCell>
+                {t.amount.toLocaleString("pt-BR", {
+                  style: "currency",
+                  currency: "BRL",
+                })}
+              </TableCell>
+              <TableCell>{t.type === "income" ? "Entrada" : "Saída"}</TableCell>
+              <TableCell>{t.category}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -7,6 +7,7 @@ import { useClients } from "@/contexts/ClientContext";
 import { useProducts } from "@/contexts/ProductContext";
 import { PageHeader } from "@/components/common/PageHeader";
 import { Plus } from "lucide-react";
+import OrderList from "@/components/orders/OrderList";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -93,6 +94,8 @@ export default function Orders() {
           icon: <Plus className="h-4 w-4" />,
         }}
       />
+
+      <OrderList />
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useTransactions } from "@/contexts/TransactionContext";
 import { PageHeader } from "@/components/common/PageHeader";
 import { Plus } from "lucide-react";
+import TransactionList from "@/components/transactions/TransactionList";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -74,6 +75,8 @@ export default function Transactions() {
           icon: <Plus className="h-4 w-4" />,
         }}
       />
+
+      <TransactionList />
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">


### PR DESCRIPTION
## Summary
- add OrderList and TransactionList components
- show OrderList on the orders page
- show TransactionList on the transactions page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6862b73b1f70832bab7c07ece56051a7