### PR TITLE
Improve client management

### DIFF
--- a/src/components/clients/ClientForm.tsx
+++ b/src/components/clients/ClientForm.tsx
@@ -1,0 +1,272 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useClients } from '@/contexts/ClientContext';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormControl,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Client } from '@/types';
+
+const schema = z.object({
+  name: z.string().min(1, 'Nome é obrigatório'),
+  email: z.string().email('E-mail inválido'),
+  phone: z.string().min(1, 'Telefone é obrigatório'),
+  document: z.string().min(1, 'Documento é obrigatório'),
+  documentType: z.enum(['cpf', 'cnpj']),
+  address: z.object({
+    street: z.string().min(1, 'Rua é obrigatória'),
+    number: z.string().min(1, 'Número é obrigatório'),
+    complement: z.string().optional(),
+    neighborhood: z.string().min(1, 'Bairro é obrigatório'),
+    city: z.string().min(1, 'Cidade é obrigatória'),
+    state: z.string().min(1, 'Estado é obrigatório'),
+    zipCode: z.string().min(1, 'CEP é obrigatório'),
+    country: z.string().min(1, 'País é obrigatório'),
+  }),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface ClientFormProps {
+  client?: Client;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+}
+
+export function ClientForm({ client, onCancel, onSuccess }: ClientFormProps) {
+  const { createClient, updateClient } = useClients();
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: client?.name ?? '',
+      email: client?.email ?? '',
+      phone: client?.phone ?? '',
+      document: client?.document ?? '',
+      documentType: client?.documentType ?? 'cpf',
+      address: {
+        street: client?.address.street ?? '',
+        number: client?.address.number ?? '',
+        complement: client?.address.complement ?? '',
+        neighborhood: client?.address.neighborhood ?? '',
+        city: client?.address.city ?? '',
+        state: client?.address.state ?? '',
+        zipCode: client?.address.zipCode ?? '',
+        country: client?.address.country ?? '',
+      },
+    },
+  });
+
+  const onSubmit = (data: FormValues) => {
+    if (client) {
+      updateClient({ ...client, ...data });
+    } else {
+      createClient({ ...data, isActive: true });
+      form.reset();
+    }
+    onSuccess?.();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nome</FormLabel>
+              <FormControl>
+                <Input placeholder="Nome completo" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="email@exemplo.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Telefone</FormLabel>
+              <FormControl>
+                <Input placeholder="(00) 00000-0000" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="document"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Documento</FormLabel>
+                <FormControl>
+                  <Input placeholder="CPF ou CNPJ" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="documentType"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tipo</FormLabel>
+                <FormControl>
+                  <select {...field} className="w-full rounded border px-2 py-1 bg-background">
+                    <option value="cpf">CPF</option>
+                    <option value="cnpj">CNPJ</option>
+                  </select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="address.street"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Rua</FormLabel>
+                <FormControl>
+                  <Input placeholder="Rua" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="address.number"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Número</FormLabel>
+                <FormControl>
+                  <Input placeholder="Número" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="address.complement"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Complemento</FormLabel>
+              <FormControl>
+                <Input placeholder="Complemento" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="address.neighborhood"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bairro</FormLabel>
+                <FormControl>
+                  <Input placeholder="Bairro" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="address.city"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Cidade</FormLabel>
+                <FormControl>
+                  <Input placeholder="Cidade" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="address.state"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Estado</FormLabel>
+                <FormControl>
+                  <Input placeholder="Estado" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="address.zipCode"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>CEP</FormLabel>
+                <FormControl>
+                  <Input placeholder="CEP" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="address.country"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>País</FormLabel>
+              <FormControl>
+                <Input placeholder="País" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end gap-4">
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancelar
+            </Button>
+          )}
+          <Button type="submit">Salvar</Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+export default ClientForm;

--- a/src/components/clients/ClientList.tsx
+++ b/src/components/clients/ClientList.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { useClients } from '@/contexts/ClientContext';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Edit, Trash } from 'lucide-react';
+import { Client } from '@/types';
+
+interface ClientListProps {
+  onEdit: (client: Client) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function ClientList({ onEdit, onDelete }: ClientListProps) {
+  const { clients } = useClients();
+  const [search, setSearch] = useState('');
+
+  const filtered = clients.filter((c) => {
+    const term = search.toLowerCase();
+    return (
+      c.name.toLowerCase().includes(term) ||
+      c.email.toLowerCase().includes(term) ||
+      c.document.includes(term)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Buscar cliente..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nome</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Documento</TableHead>
+            <TableHead>Telefone</TableHead>
+            <TableHead className="text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((c) => (
+            <TableRow key={c.id}>
+              <TableCell>{c.name}</TableCell>
+              <TableCell>{c.email}</TableCell>
+              <TableCell>{c.document}</TableCell>
+              <TableCell>{c.phone}</TableCell>
+              <TableCell className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => onEdit(c)}>
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => onDelete(c.id)}>
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,72 +1,34 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useClients } from "@/contexts/ClientContext";
-import { PageHeader } from "@/components/common/PageHeader";
-import { Plus } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-
-const clientSchema = z.object({
-  name: z.string().min(1, "Nome é obrigatório"),
-  email: z.string().email("E-mail inválido"),
-  phone: z.string().min(1, "Telefone é obrigatório"),
-  document: z.string().min(1, "Documento é obrigatório"),
-  documentType: z.enum(["cpf", "cnpj"]),
-});
-
-type ClientFormValues = z.infer<typeof clientSchema>;
+import { useState } from 'react';
+import { PageHeader } from '@/components/common/PageHeader';
+import { Plus } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useClients } from '@/contexts/ClientContext';
+import ClientForm from '@/components/clients/ClientForm';
+import ClientList from '@/components/clients/ClientList';
+import { Client } from '@/types';
 
 export default function Clients() {
-  const { createClient } = useClients();
+  const { deleteClient } = useClients();
+  const [editingClient, setEditingClient] = useState<Client | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const form = useForm<ClientFormValues>({
-    resolver: zodResolver(clientSchema),
-    defaultValues: {
-      name: "",
-      email: "",
-      phone: "",
-      document: "",
-      documentType: "cpf",
-    },
-  });
+  const openNew = () => {
+    setEditingClient(null);
+    setIsDialogOpen(true);
+  };
 
-  const onSubmit = async (data: ClientFormValues) => {
-    try {
-      await createClient({
-        ...data,
-        address: {
-          street: "",
-          number: "",
-          neighborhood: "",
-          city: "",
-          state: "",
-          zipCode: "",
-          country: "",
-        },
-        isActive: true,
-      });
-      setIsDialogOpen(false);
-      form.reset();
-    } catch (err) {
-      console.error("Erro ao criar cliente", err);
-    }
+  const openEdit = (client: Client) => {
+    setEditingClient(client);
+    setIsDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    setEditingClient(null);
+  };
+
+  const handleDelete = (id: string) => {
+    deleteClient(id);
   };
 
   return (
@@ -74,106 +36,20 @@ export default function Clients() {
       <PageHeader
         title="Clientes"
         description="Gerencie sua base de clientes"
-        action={{
-          label: "Novo Cliente",
-          onClick: () => setIsDialogOpen(true),
-          icon: <Plus className="h-4 w-4" />,
-        }}
+        action={{ label: 'Novo Cliente', onClick: openNew, icon: <Plus className="h-4 w-4" /> }}
       />
+      <ClientList onEdit={openEdit} onDelete={handleDelete} />
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
-            <DialogTitle>Novo Cliente</DialogTitle>
+            <DialogTitle>{editingClient ? 'Editar Cliente' : 'Novo Cliente'}</DialogTitle>
           </DialogHeader>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Nome</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Nome completo" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input type="email" placeholder="email@exemplo.com" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="phone"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Telefone</FormLabel>
-                    <FormControl>
-                      <Input placeholder="(00) 00000-0000" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <div className="grid grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="document"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Documento</FormLabel>
-                      <FormControl>
-                        <Input placeholder="CPF ou CNPJ" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="documentType"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Tipo</FormLabel>
-                      <FormControl>
-                        <select
-                          {...field}
-                          className="w-full rounded border px-2 py-1 bg-background"
-                        >
-                          <option value="cpf">CPF</option>
-                          <option value="cnpj">CNPJ</option>
-                        </select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <div className="flex justify-end gap-4">
-                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
-                  Cancelar
-                </Button>
-                <Button type="submit">Salvar</Button>
-              </div>
-            </form>
-          </Form>
+          <ClientForm
+            client={editingClient ?? undefined}
+            onCancel={closeDialog}
+            onSuccess={closeDialog}
+          />
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- add reusable `ClientForm` with validation for full client info
- add searchable `ClientList`
- refactor clients page to use new components for create and edit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862b9310c54832b9124d58e3adbc141